### PR TITLE
Allow multiple meta tags of the same name

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function parseMetadata (opts, html, contentType) {
 
   if (opts.fields.title) {
     // parse the <title> tag:
-    metadata.title = $('head title').last().text();
+    metadata.title = $('head title').first().text();
   }
   return metadata;
 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ function parseMetadata (opts, html, contentType) {
 
       // if there is a name key, add it to the meta object, otherwise discard:
       if (m.name && m.content) {
-        metadata.meta[m.name] = m.content;
+        if (metadata.meta[m.name]) {
+          metadata.meta[m.name + 's'] = metadata.meta[m.name + 's'] || [metadata.meta[m.name]]
+          metadata.meta[m.name + 's'].push(m.content)
+        } else {
+          metadata.meta[m.name] = m.content;
+        }
       }
     });
   }

--- a/test/index.js
+++ b/test/index.js
@@ -82,5 +82,5 @@ describe('node-web-metadata', function () {
       assert.notEqual(data.url, null);
       done();
     });
-  });
+  }).timeout(5000);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ describe('node-web-metadata', function () {
   });
 
   it('returns data on success', function (done) {
-    metadata({url:'http://leap.it'}, function (err, data) {
+    metadata({url:'http://google.com'}, function (err, data) {
       assert.equal(err, null);
       assert.notEqual(data, null);
       done();
@@ -41,8 +41,9 @@ describe('node-web-metadata', function () {
     fs.readFile('test/html/malformed_multiple_head_tags.html', 'utf8', function (err, data) {
       metadata({html:data}, function (err, data) {
         assert.equal(err, null);
-        assert.equal(data.meta.description, 'test description #2');
-        assert.equal(data.title, 'testing head #2');
+        assert.equal(data.meta.description, 'test description #1');
+        assert.equal(data.title, 'testing head #1');
+        assert.deepEqual(data.meta.descriptions, ['test description #1', 'test description #2'])
         done();
       });
     });
@@ -60,7 +61,7 @@ describe('node-web-metadata', function () {
   });
 
   it('will return contentType for a website url', function (done) {
-    metadata({url:'http://leap.it'}, function (err, data) {
+    metadata({url:'http://google.com'}, function (err, data) {
       assert(data.contentType.indexOf('text/html') !== -1);
       assert.notEqual(data.url, null);
       done();
@@ -68,7 +69,7 @@ describe('node-web-metadata', function () {
   });
 
   it('will return contentType for an image url', function (done) {
-    metadata({url:'http://leap2-marketing.s3.amazonaws.com/leapit-300x300.jpg'}, function (err, data) {
+    metadata({url:'https://placekitten.com/g/200/300'}, function (err, data) {
       assert(data.contentType.indexOf('image/jpeg') !== -1);
       assert.notEqual(data.url, null);
       done();
@@ -76,7 +77,7 @@ describe('node-web-metadata', function () {
   });
 
   it('will return contentType for a video url', function (done) {
-    metadata({url:'http://videos-f-8.ak.instagram.com/hphotos-ak-ash/10381557_1558605304366028_1049389520_n.mp4'}, function (err, data) {
+    metadata({url:'http://scontent-sin1-1.cdninstagram.com/t50.2886-16/13248162_1066593200053350_416643217_n.mp4'}, function (err, data) {
       assert(data.contentType.indexOf('video/mp4') !== -1);
       assert.notEqual(data.url, null);
       done();


### PR DESCRIPTION
It is possible to have multiple `og:image` tags etc. This pull request adds them into an array with an `s` at the end of the name of the tag. It keeps the first tag it finds as `og:image` and if it finds more it will create an array with the key `og:images`, and add the original one to this array as well as the next item it finds.
